### PR TITLE
Change domain so Google oauth works

### DIFF
--- a/backend/apollo/users/urls.py
+++ b/backend/apollo/users/urls.py
@@ -6,10 +6,6 @@ from apollo.users.views import UserViewSet
 router = routers.DefaultRouter()
 router.register('users', UserViewSet)
 
-apipatterns = [
-    path('', include(router.urls)),
-]
-
 urlpatterns = [
-    path('api/', include(apipatterns))
+    path('', include(router.urls)),
 ]

--- a/backend/config/settings/local.py
+++ b/backend/config/settings/local.py
@@ -10,4 +10,4 @@ MIDDLEWARE = ["debug_toolbar.middleware.DebugToolbarMiddleware"] + MIDDLEWARE
 
 ip = socket.gethostbyname(socket.gethostname())
 INTERNAL_IPS += [ip[:-1] + "1"]
-ALLOWED_HOSTS += ["apollo.localhost"]
+ALLOWED_HOSTS += ["localhost"]

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -20,18 +20,22 @@ from django.conf.urls.static import static
 
 from apollo.users import urls as users_urls
 
-urlpatterns = []
+apipatterns = []
 
 if settings.DEBUG:
     import debug_toolbar
 
-    urlpatterns += [path("__debug__/", include(debug_toolbar.urls))]
+    apipatterns += [path("__debug__/", include(debug_toolbar.urls))]
 
 
-urlpatterns += [
+apipatterns += [
     path("admin/", admin.site.urls),
     path("api-auth/", include("rest_framework.urls")),
     path('', include("social_django.urls", namespace="social"))
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
 
-urlpatterns += users_urls.urlpatterns
+apipatterns += users_urls.urlpatterns
+
+urlpatterns = [
+    path('api/', include(apipatterns))
+]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - ./backend:/app
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.app.rule=Host(`apollo.localhost`) && PathPrefix(`/api`)"
+      - "traefik.http.routers.app.rule=Host(`localhost`) && PathPrefix(`/api`)"
       - "traefik.http.routers.app.entrypoints=app"
       # - "traefik.http.routers.app.priority=42"
 
@@ -43,7 +43,7 @@ services:
       - 19006:19006
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.web.rule=Host(`apollo.localhost`)"
+      - "traefik.http.routers.web.rule=Host(`localhost`)"
       - "traefik.http.services.web.loadbalancer.server.port=19006"
       - "traefik.http.routers.web.entrypoints=app"
 


### PR DESCRIPTION
Google OAuth2 doesn't allow non-public domains to be used for redirections. `apollo.localhost`, while looking nice is not allowed and we need to use plain old `localhost` which seems to be whitelisted.