### PR TITLE
Encrypt votes

### DIFF
--- a/backend/apollo/elections/crypto.py
+++ b/backend/apollo/elections/crypto.py
@@ -13,9 +13,7 @@ def decrypt(election_secret_key: str, ciphertext: str) -> str:
         )
         sealed_box = nacl.public.SealedBox(election_sk)
         message = sealed_box.decrypt(ciphertext, encoder).decode()
-    except TypeError as e:
-        raise
-    except nacl.exceptions.CryptoError as e:
+    except (TypeError, nacl.exceptions.CryptoError) as e:
         raise CryptoError from e
 
     return message

--- a/backend/apollo/elections/crypto.py
+++ b/backend/apollo/elections/crypto.py
@@ -1,0 +1,21 @@
+import nacl
+
+
+class CryptoError(Exception):
+    pass
+
+
+def decrypt(election_secret_key: str, ciphertext: str) -> str:
+    encoder = nacl.encoding.Base64Encoder()
+    try:
+        election_sk = nacl.public.PrivateKey(
+            election_secret_key.encode("ascii"), encoder
+        )
+        sealed_box = nacl.public.SealedBox(election_sk)
+        message = sealed_box.decrypt(ciphertext, encoder).decode()
+    except TypeError as e:
+        raise
+    except nacl.exceptions.CryptoError as e:
+        raise CryptoError from e
+
+    return message

--- a/backend/apollo/elections/serializers.py
+++ b/backend/apollo/elections/serializers.py
@@ -1,5 +1,8 @@
 from typing import Any, Dict, List
 
+from rest_framework.exceptions import ValidationError
+from rest_framework.generics import get_object_or_404
+
 from apollo.elections import permissions
 
 import django_fsm
@@ -11,6 +14,7 @@ from drf_writable_nested import serializers as nested
 from apollo.elections.models import Answer, Election, Question, Vote
 from apollo.elections.models.election import VoterAuthorizationRule
 from apollo.common import serializers as apollo_serializers
+from apollo.elections.crypto import decrypt, CryptoError
 
 
 class AnswerSerializer(serializers.ModelSerializer):
@@ -55,16 +59,52 @@ class VoteSerializer(
 
     answer = serializers.PrimaryKeyRelatedField(queryset=Answer.objects.all())
     author = serializers.HiddenField(default=CurrentUserDefault())
+    election = serializers.PrimaryKeyRelatedField(queryset=Election.objects.all(), write_only=True)
 
     class Meta:
         model = Vote
-        fields = ["id", "answer", "author"]
+        fields = ["id", "answer", "author", "election"]
         read_only_fields = ["id"]
+        write_only_fields = ["election"]
         validators = [
             UniqueTogetherValidator(
                 queryset=Vote.objects.all(), fields=["author", "answer"]
             )
         ]
+
+    def is_valid(self, raise_exception=False):
+        try:
+            answer_id_ciphertext = self.initial_data["answer"]
+            election_id = self.initial_data["election"]
+        except KeyError:
+            if raise_exception:
+                raise ValidationError()
+            return False
+
+        election = get_object_or_404(Election, pk=election_id)
+
+        try:
+            answer_id = decrypt(election.secret_key, answer_id_ciphertext)
+        except CryptoError:
+            if raise_exception:
+                raise ValidationError()
+            return False
+
+        answer = get_object_or_404(Answer, pk=answer_id)
+
+        if answer.question.election.id != election_id:
+            if raise_exception:
+                raise ValidationError()
+            return False
+
+        self.initial_data["answer"] = answer_id
+
+        return super().is_valid(raise_exception)
+
+    def create(self, validated_data):
+        validated_data.pop("election")
+        vote = Vote.objects.create(**validated_data)
+        return vote
 
 
 class VoterAuthorizationRuleSerializer(serializers.ModelSerializer):

--- a/backend/apollo/elections/serializers.py
+++ b/backend/apollo/elections/serializers.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Dict, List
 
 from rest_framework.exceptions import ValidationError
 from rest_framework.generics import get_object_or_404
@@ -83,7 +83,10 @@ class VoteSerializer(
     def is_valid(self, raise_exception):
         try:
             answer_id = self._decrypt_answer()
-        except (KeyError, CryptoError, ValidationError):
+        except KeyError as e:
+            if raise_exception:
+                raise ValidationError(f"Missing parameter {e}")
+        except (CryptoError, ValidationError):
             if raise_exception:
                 raise ValidationError()
 

--- a/backend/apollo/elections/views.py
+++ b/backend/apollo/elections/views.py
@@ -117,11 +117,10 @@ class VoteViewSet(viewsets.GenericViewSet):
         try:
             encoder = nacl.encoding.Base64Encoder()
             election_sk = nacl.public.PrivateKey(
-                election.secret_key.encode("ascii"),
-                encoder
+                election.secret_key.encode("ascii"), encoder
             )
             sealed_box = nacl.public.SealedBox(election_sk)
-            answer_id = sealed_box.decrypt(answer_id_ciphertext, encoder).decode("utf-8")
+            answer_id = sealed_box.decrypt(answer_id_ciphertext, encoder).decode()
         except nacl.exceptions.CryptoError:
             return Response(status=status.HTTP_400_BAD_REQUEST)
 

--- a/backend/tests/elections/test_votes.py
+++ b/backend/tests/elections/test_votes.py
@@ -2,6 +2,7 @@ from typing import TypedDict
 
 from apollo.users.models import User
 from pytest import mark, fixture
+from unittest.mock import MagicMock
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
@@ -9,14 +10,14 @@ from rest_framework.test import APIClient
 
 from apollo.elections.models import Answer, Vote, Election
 
-VotePostData = TypedDict("VotePostData", {"answer": int})
+VotePostData = TypedDict("VotePostData", {"answer": int, "election": int})
 
 pytestmark = mark.django_db
 
 
 @fixture
 def vote_data(answer: Answer) -> VotePostData:
-    return {"answer": answer.id}
+    return {"answer": answer.id, "election": answer.question.election.id}
 
 
 @fixture
@@ -26,6 +27,13 @@ def eligible_voter(
     user = user_factory()
     voter_authorization_rule_factory(election=election, value=user.email)
     return user
+
+
+@fixture
+def decrypt_mock(mocker, answer: Answer):
+    mock = mocker.patch("apollo.elections.serializers.decrypt")
+    mock.return_value = answer.id
+    return mock
 
 
 def _create_vote(
@@ -38,7 +46,10 @@ def _create_vote(
 
 
 def test_create_vote(
-    api_client: APIClient, vote_data: VotePostData, eligible_voter: User
+    api_client: APIClient,
+    vote_data: VotePostData,
+    eligible_voter: User,
+    decrypt_mock: MagicMock,
 ) -> None:
     response = _create_vote(api_client, vote_data, eligible_voter)
     assert response.status_code == status.HTTP_201_CREATED
@@ -48,28 +59,35 @@ def test_create_vote(
     )
 
 
-def test_create_vote_twice_on_the_same_thing(api_client: APIClient, vote: Vote) -> None:
-    response = _create_vote(api_client, {"answer": vote.answer.id}, vote.author)
+def test_create_vote_twice_on_the_same_thing(
+    api_client: APIClient, vote: Vote, decrypt_mock: MagicMock
+) -> None:
+    response = _create_vote(
+        api_client,
+        {"answer": vote.answer.id, "election": vote.answer.question.election.id},
+        vote.author,
+    )
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
 def test_cannot_create_for_non_existent_question(
-    api_client: APIClient, vote_data: VotePostData, user: User
+    api_client: APIClient, vote_data: VotePostData, user: User, decrypt_mock: MagicMock
 ) -> None:
-    vote_data["answer"] = 667
+    non_existent_answer_id = 667
+    vote_data["answer"] = non_existent_answer_id
+    decrypt_mock.return_value = non_existent_answer_id
     response = _create_vote(api_client, vote_data, user)
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert "answer" in response.data
+    assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
-@mark.parametrize("param", ["answer"])
+@mark.parametrize("param", ["answer", "election"])
 def test_cannot_be_created_without_all_required_params(
     api_client: APIClient, param: str, vote_data: VotePostData, user: User
 ) -> None:
     del vote_data[param]
     response = _create_vote(api_client, vote_data, user)
     assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert param in response.data
+    assert param in str(response.data)
 
 
 def test_cannot_be_created_without_logging_in(vote_data: VotePostData) -> None:
@@ -81,7 +99,7 @@ def test_cannot_be_created_without_logging_in(vote_data: VotePostData) -> None:
 
 
 def test_unauthorized_user_cannot_vote(
-    api_client: APIClient, vote_data: VotePostData, user
+    api_client: APIClient, vote_data: VotePostData, user: User, decrypt_mock: MagicMock
 ) -> None:
     response = _create_vote(api_client, vote_data, user)
     assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "axios": "^0.19.2",
+    "blakejs": "^1.1.0",
     "bootstrap": "^4.5.0",
     "bootstrap-vue": "^2.14.0",
     "core-js": "^3.6.4",

--- a/frontend/src/crypto/encryption.ts
+++ b/frontend/src/crypto/encryption.ts
@@ -1,0 +1,35 @@
+import { box, randomBytes } from "tweetnacl";
+import { decodeBase64, encodeBase64, decodeUTF8 } from "tweetnacl-util";
+import blake from "blakejs/blake2b";
+
+
+function sealedBoxNonce(publicKeySender: Uint8Array, publicKeyReceiver: Uint8Array): Uint8Array {
+    const state = blake.blake2bInit(box.nonceLength, null);
+    blake.blake2bUpdate(state, publicKeySender);
+    blake.blake2bUpdate(state, publicKeyReceiver);
+    return blake.blake2bFinal(state);
+}
+
+export function encrypt(electionKey: string, message: string): string {
+    /**
+     * NaCl sealed box encryption
+     * see https://libsodium.gitbook.io/doc/public-key_cryptography/sealed_boxes
+     */
+    const electionKeyDecoded = decodeBase64(electionKey);
+    const ephemeralKeyPair = box.keyPair();
+    const nonce = sealedBoxNonce(ephemeralKeyPair.publicKey, electionKeyDecoded);
+
+    const encryptedMessage = box(
+        decodeUTF8(message),
+        nonce,
+        electionKeyDecoded,
+        ephemeralKeyPair.secretKey
+    );
+
+    const ciphertext = new Uint8Array(ephemeralKeyPair.publicKey.length + encryptedMessage.length);
+    ciphertext.set(ephemeralKeyPair.publicKey);
+    ciphertext.set(encryptedMessage, ephemeralKeyPair.publicKey.length);
+
+
+    return encodeBase64(ciphertext);
+}

--- a/frontend/src/crypto/encryption.ts
+++ b/frontend/src/crypto/encryption.ts
@@ -1,35 +1,38 @@
-import { box, randomBytes } from "tweetnacl";
+import { box } from "tweetnacl";
 import { decodeBase64, encodeBase64, decodeUTF8 } from "tweetnacl-util";
 import blake from "blakejs/blake2b";
 
-
-function sealedBoxNonce(publicKeySender: Uint8Array, publicKeyReceiver: Uint8Array): Uint8Array {
-    const state = blake.blake2bInit(box.nonceLength, null);
-    blake.blake2bUpdate(state, publicKeySender);
-    blake.blake2bUpdate(state, publicKeyReceiver);
-    return blake.blake2bFinal(state);
+function sealedBoxNonce(
+  publicKeySender: Uint8Array,
+  publicKeyReceiver: Uint8Array
+): Uint8Array {
+  const state = blake.blake2bInit(box.nonceLength, null);
+  blake.blake2bUpdate(state, publicKeySender);
+  blake.blake2bUpdate(state, publicKeyReceiver);
+  return blake.blake2bFinal(state);
 }
 
 export function encrypt(electionKey: string, message: string): string {
-    /**
-     * NaCl sealed box encryption
-     * see https://libsodium.gitbook.io/doc/public-key_cryptography/sealed_boxes
-     */
-    const electionKeyDecoded = decodeBase64(electionKey);
-    const ephemeralKeyPair = box.keyPair();
-    const nonce = sealedBoxNonce(ephemeralKeyPair.publicKey, electionKeyDecoded);
+  /**
+   * NaCl sealed box encryption
+   * see https://libsodium.gitbook.io/doc/public-key_cryptography/sealed_boxes
+   */
+  const electionKeyDecoded = decodeBase64(electionKey);
+  const ephemeralKeyPair = box.keyPair();
+  const nonce = sealedBoxNonce(ephemeralKeyPair.publicKey, electionKeyDecoded);
 
-    const encryptedMessage = box(
-        decodeUTF8(message),
-        nonce,
-        electionKeyDecoded,
-        ephemeralKeyPair.secretKey
-    );
+  const encryptedMessage = box(
+    decodeUTF8(message),
+    nonce,
+    electionKeyDecoded,
+    ephemeralKeyPair.secretKey
+  );
 
-    const ciphertext = new Uint8Array(ephemeralKeyPair.publicKey.length + encryptedMessage.length);
-    ciphertext.set(ephemeralKeyPair.publicKey);
-    ciphertext.set(encryptedMessage, ephemeralKeyPair.publicKey.length);
+  const ciphertext = new Uint8Array(
+    ephemeralKeyPair.publicKey.length + encryptedMessage.length
+  );
+  ciphertext.set(ephemeralKeyPair.publicKey);
+  ciphertext.set(encryptedMessage, ephemeralKeyPair.publicKey.length);
 
-
-    return encodeBase64(ciphertext);
+  return encodeBase64(ciphertext);
 }

--- a/frontend/src/views/VotePage.vue
+++ b/frontend/src/views/VotePage.vue
@@ -11,6 +11,7 @@ import Vue from "vue";
 import { ApiElection } from "@/api/elections";
 import ElectionVoteForm, { Vote } from "@/components/ElectionVoteForm.vue";
 import { AxiosError } from "axios";
+import { encrypt } from "@/crypto/encryption";
 
 export default Vue.extend({
   components: {
@@ -36,10 +37,13 @@ export default Vue.extend({
         if (vote.selected === null) {
           return Promise.reject("Vote is null");
         }
+        if (this.election === null) {
+          return Promise.reject("Election is null");
+        }
 
         const [question, answer] = vote.selected.split(".");
 
-        return this.$http.post("/api/elections/votes/", { answer });
+        return this.$http.post("/api/elections/votes/", { answer: encrypt(this.election.public_key, answer) });
       });
       Promise.all(results).then(
         () => {

--- a/frontend/src/views/VotePage.vue
+++ b/frontend/src/views/VotePage.vue
@@ -43,7 +43,10 @@ export default Vue.extend({
 
         const [question, answer] = vote.selected.split(".");
 
-        return this.$http.post("/api/elections/votes/", { answer: encrypt(this.election.public_key, answer) });
+        return this.$http.post(
+          "/api/elections/votes/",
+          { answer: encrypt(this.election.public_key, answer), election: this.election.id }
+        );
       });
       Promise.all(results).then(
         () => {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1958,6 +1958,11 @@ bindings@^1.5.0:
   dependencies:
     file-uri-to-path "1.0.0"
 
+blakejs@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/blakejs/-/blakejs-1.1.0.tgz#69df92ef953aa88ca51a32df6ab1c54a155fc7a5"
+  integrity sha1-ad+S75U6qIylGjLfarHFShVfx6U=
+
 bluebird@3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.0.tgz#791420d7f551eea2897453a8a77653f96606d67c"


### PR DESCRIPTION
Send votes from frontend to backend encrypted using election's public key.
The encryption used: libsodium Sealedbox encryption (https://libsodium.gitbook.io/doc/public-key_cryptography/sealed_boxes)

TLDR it's using authenticated encryption but as the authentication is not needed (user so far has any key) the sender keys are just temporary values, and the nonce is generated based on the sender public key (which is random)

The frontend lib tweetnacl doesn't provide Sealedbox, but it is the matter of nonce generation, which I did myself basing on https://github.com/whs/tweetnacl-sealed-box